### PR TITLE
Add break-even ticket analysis and cost inputs

### DIFF
--- a/restaurant-business-calculator/index.html
+++ b/restaurant-business-calculator/index.html
@@ -225,6 +225,14 @@
                             <label for="ticket-delivery">Average Ticket - Delivery ($)</label>
                             <input type="number" id="ticket-delivery" value="15" step="0.01" class="input-full">
                         </div>
+                        <div class="input-group">
+                            <label for="cogs-percent">Cost of Goods (%)</label>
+                            <input type="number" id="cogs-percent" value="35" min="0" max="100" class="input-full">
+                        </div>
+                        <div class="input-group">
+                            <label for="delivery-commission">Delivery App Commission (%)</label>
+                            <input type="number" id="delivery-commission" value="0" min="0" max="100" class="input-full">
+                        </div>
                     </div>
 
                     <!-- Sales Distribution -->
@@ -357,6 +365,14 @@
                             <div class="info-item">
                                 <span class="info-label">Monthly Break-Even Sales</span>
                                 <span class="info-value" id="breakeven-sales">$18,500</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Break-Even Tickets</span>
+                                <span class="info-value" id="breakeven-tickets">0</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Average Cost per Ticket</span>
+                                <span class="info-value" id="avg-cost-ticket">$0</span>
                             </div>
                         </div>
                         <canvas id="breakeven-chart" class="chart-container"></canvas>

--- a/restaurant-business-calculator/js/app.js
+++ b/restaurant-business-calculator/js/app.js
@@ -28,6 +28,8 @@ const AppState = {
                 inStore: 0.5,
                 delivery: 0.5
             },
+            cogsPercent: 0.35,
+            deliveryCommission: 0,
             itemsPerTicket: 6,
             monthlyTickets: 1333,
             dailyTickets: 67
@@ -41,7 +43,9 @@ const AppState = {
             year2: { sales: 0, costs: 0, profit: 0, margin: 0 },
             roi: 0,
             breakEvenMonths: 0,
-            breakEvenSales: 0
+            breakEvenSales: 0,
+            breakEvenTickets: 0,
+            avgCostPerTicket: 0
         }
     },
     isCalculating: false,
@@ -221,6 +225,19 @@ function setupPremisesListeners() {
         updatePremisesCalculations();
         markUnsavedChanges();
     });
+
+    // Cost percentages
+    document.getElementById('cogs-percent').addEventListener('input', (e) => {
+        AppState.data.premises.cogsPercent = (parseFloat(e.target.value) || 0) / 100;
+        updatePremisesCalculations();
+        markUnsavedChanges();
+    });
+
+    document.getElementById('delivery-commission').addEventListener('input', (e) => {
+        AppState.data.premises.deliveryCommission = (parseFloat(e.target.value) || 0) / 100;
+        updatePremisesCalculations();
+        markUnsavedChanges();
+    });
     
     // Sales Ratio
     const ratioInstore = document.getElementById('ratio-instore');
@@ -282,28 +299,29 @@ function updateInvestmentSummary() {
 // Update Premises Calculations
 function updatePremisesCalculations() {
     const premises = AppState.data.premises;
-    
-    // Calculate monthly tickets based on initial assumptions
-    // This is a simplified calculation - in reality, you'd want more complex modeling
-    const avgTicketPrice = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
+
+    // Calculate average ticket values
+    const avgTicketGross = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
                           (premises.averageTicket.delivery * premises.ticketRatio.delivery);
-    
-    // Assuming target monthly revenue and calculating tickets needed
+    const commissionPerTicket = premises.averageTicket.delivery * premises.deliveryCommission * premises.ticketRatio.delivery;
+    const avgTicketNet = avgTicketGross - commissionPerTicket;
+
+    // Assuming target monthly revenue (net) and calculating tickets needed
     const targetMonthlyRevenue = 20000; // Base assumption
-    premises.monthlyTickets = Math.round(targetMonthlyRevenue / avgTicketPrice);
+    premises.monthlyTickets = Math.round(targetMonthlyRevenue / avgTicketNet);
     premises.dailyTickets = Math.round(premises.monthlyTickets / premises.workingDays);
-    
+
     // Update UI
-    document.getElementById('monthly-tickets').textContent = 
+    document.getElementById('monthly-tickets').textContent =
         premises.monthlyTickets.toLocaleString();
-    document.getElementById('daily-tickets').textContent = 
+    document.getElementById('daily-tickets').textContent =
         premises.dailyTickets.toLocaleString();
-    document.getElementById('monthly-revenue').textContent = 
-        formatCurrency(premises.monthlyTickets * avgTicketPrice);
-    
+    document.getElementById('monthly-revenue').textContent =
+        formatCurrency(premises.monthlyTickets * avgTicketNet);
+
     // Update chart
     updatePremisesChart();
-    
+
     // Trigger cash flow recalculation
     generateCashFlow();
 }
@@ -371,6 +389,8 @@ function initializeDefaultValues() {
     document.getElementById('avg-items').value = 6;
     document.getElementById('ticket-instore').value = 15;
     document.getElementById('ticket-delivery').value = 15;
+    document.getElementById('cogs-percent').value = 35;
+    document.getElementById('delivery-commission').value = 0;
     
     // Update state
     updateInvestmentItem('civilWorks', 'quantity', 1);
@@ -605,6 +625,8 @@ function updateUIFromState() {
     document.getElementById('avg-items').value = prem.itemsPerTicket;
     document.getElementById('ticket-instore').value = prem.averageTicket.inStore;
     document.getElementById('ticket-delivery').value = prem.averageTicket.delivery;
+    document.getElementById('cogs-percent').value = (prem.cogsPercent || 0) * 100;
+    document.getElementById('delivery-commission').value = (prem.deliveryCommission || 0) * 100;
     document.getElementById('ratio-instore').value = prem.ticketRatio.inStore * 100;
     document.getElementById('ratio-instore-value').textContent = (prem.ticketRatio.inStore * 100) + '%';
     document.getElementById('ratio-delivery-value').textContent = (prem.ticketRatio.delivery * 100) + '%';
@@ -632,6 +654,8 @@ function loadTemplate(templateName) {
                 workingDays: 26,
                 averageTicket: { inStore: 12, delivery: 15 },
                 ticketRatio: { inStore: 0.7, delivery: 0.3 },
+                cogsPercent: 0.35,
+                deliveryCommission: 0,
                 itemsPerTicket: 4,
                 monthlyTickets: 1667,
                 dailyTickets: 64
@@ -655,6 +679,8 @@ function loadTemplate(templateName) {
                 workingDays: 24,
                 averageTicket: { inStore: 25, delivery: 30 },
                 ticketRatio: { inStore: 0.85, delivery: 0.15 },
+                cogsPercent: 0.35,
+                deliveryCommission: 0,
                 itemsPerTicket: 6,
                 monthlyTickets: 800,
                 dailyTickets: 33
@@ -678,6 +704,8 @@ function loadTemplate(templateName) {
                 workingDays: 22,
                 averageTicket: { inStore: 75, delivery: 85 },
                 ticketRatio: { inStore: 0.95, delivery: 0.05 },
+                cogsPercent: 0.35,
+                deliveryCommission: 0,
                 itemsPerTicket: 8,
                 monthlyTickets: 267,
                 dailyTickets: 12
@@ -701,6 +729,8 @@ function loadTemplate(templateName) {
                 workingDays: 20,
                 averageTicket: { inStore: 10, delivery: 0 },
                 ticketRatio: { inStore: 1.0, delivery: 0 },
+                cogsPercent: 0.35,
+                deliveryCommission: 0,
                 itemsPerTicket: 3,
                 monthlyTickets: 2000,
                 dailyTickets: 100
@@ -724,6 +754,8 @@ function loadTemplate(templateName) {
                 workingDays: 28,
                 averageTicket: { inStore: 8, delivery: 10 },
                 ticketRatio: { inStore: 0.8, delivery: 0.2 },
+                cogsPercent: 0.35,
+                deliveryCommission: 0,
                 itemsPerTicket: 2.5,
                 monthlyTickets: 2500,
                 dailyTickets: 89

--- a/restaurant-business-calculator/js/calculator.js
+++ b/restaurant-business-calculator/js/calculator.js
@@ -5,10 +5,12 @@ function generateCashFlow() {
     const premises = AppState.data.premises;
     const investment = AppState.data.investment;
     
-    // Calculate monthly revenue
-    const avgTicketPrice = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
+    // Calculate monthly revenue (net of delivery commission)
+    const avgTicketGross = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
                           (premises.averageTicket.delivery * premises.ticketRatio.delivery);
-    const monthlyRevenue = premises.monthlyTickets * avgTicketPrice;
+    const commissionPerTicket = premises.averageTicket.delivery * premises.deliveryCommission * premises.ticketRatio.delivery;
+    const avgTicketNet = avgTicketGross - commissionPerTicket;
+    const monthlyRevenue = premises.monthlyTickets * avgTicketNet;
     
     // Year 1 Cash Flow
     const year1CashFlow = generateYearCashFlow(monthlyRevenue, 1, investment);
@@ -44,7 +46,7 @@ function generateYearCashFlow(baseMonthlyRevenue, year, investment) {
         const revenue = baseMonthlyRevenue * seasonalFactor;
         
         // Cost calculations (percentages based on industry standards)
-        const cogs = revenue * 0.35; // 35% cost of goods sold
+        const cogs = revenue * AppState.data.premises.cogsPercent; // Cost of goods sold
         const labor = revenue * 0.30; // 30% labor costs
         const rent = 5000; // Fixed rent
         const utilities = revenue * 0.05; // 5% utilities
@@ -222,9 +224,17 @@ function calculateResults() {
     AppState.data.results.roi = (totalReturn / totalInvestment) * 100;
     
     // Break-even Analysis
+    const premises = AppState.data.premises;
     const monthlyFixedCosts = 5000 + 2000; // Rent + base loan
-    const contributionMargin = 1 - 0.35; // 1 - COGS ratio
+    const avgTicketGross = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
+                           (premises.averageTicket.delivery * premises.ticketRatio.delivery);
+    const commissionRatio = (premises.averageTicket.delivery * premises.deliveryCommission * premises.ticketRatio.delivery) / avgTicketGross;
+    const variableCostRatio = premises.cogsPercent + commissionRatio;
+    const contributionMargin = 1 - variableCostRatio;
     AppState.data.results.breakEvenSales = monthlyFixedCosts / contributionMargin;
+    const avgVariableCostPerTicket = avgTicketGross * variableCostRatio;
+    AppState.data.results.breakEvenTickets = Math.ceil(AppState.data.results.breakEvenSales / avgTicketGross);
+    AppState.data.results.avgCostPerTicket = avgVariableCostPerTicket;
     
     // Find break-even month
     let breakEvenMonth = 0;
@@ -250,6 +260,8 @@ function updateResultsTab() {
     // Update break-even info
     document.getElementById('breakeven-months').textContent = results.breakEvenMonths + ' months';
     document.getElementById('breakeven-sales').textContent = formatCurrency(results.breakEvenSales);
+    document.getElementById('breakeven-tickets').textContent = results.breakEvenTickets.toLocaleString();
+    document.getElementById('avg-cost-ticket').textContent = formatCurrency(results.avgCostPerTicket);
     
     // Update financial summary
     const totalInvestment = getTotalInvestment(AppState.data.investment);

--- a/restaurant-business-calculator/js/charts.js
+++ b/restaurant-business-calculator/js/charts.js
@@ -84,7 +84,7 @@ function updatePremisesChart() {
     
     // Calculate data for visualization
     const inStoreRevenue = premises.monthlyTickets * premises.ticketRatio.inStore * premises.averageTicket.inStore;
-    const deliveryRevenue = premises.monthlyTickets * premises.ticketRatio.delivery * premises.averageTicket.delivery;
+    const deliveryRevenue = premises.monthlyTickets * premises.ticketRatio.delivery * premises.averageTicket.delivery * (1 - premises.deliveryCommission);
     
     chartInstances.premises = new Chart(ctx, {
         type: 'bar',
@@ -406,7 +406,11 @@ function updateBreakEvenChart() {
     const totalCosts = [];
     const revenues = [];
     const monthlyRevenue = AppState.data.results.year1.sales / 12;
-    const variableCostRatio = 0.65; // 65% variable costs
+    const premises = AppState.data.premises;
+    const avgTicketGross = (premises.averageTicket.inStore * premises.ticketRatio.inStore) +
+                           (premises.averageTicket.delivery * premises.ticketRatio.delivery);
+    const commissionRatio = (premises.averageTicket.delivery * premises.deliveryCommission * premises.ticketRatio.delivery) / avgTicketGross;
+    const variableCostRatio = premises.cogsPercent + commissionRatio;
     
     for (let i = 0; i < 24; i++) {
         const revenue = monthlyRevenue * (i + 1);

--- a/restaurant-business-calculator/js/export.js
+++ b/restaurant-business-calculator/js/export.js
@@ -59,6 +59,9 @@ function exportToPDF() {
         ['Year 2 Projected Revenue', formatCurrency(AppState.data.results.year2.sales)],
         ['Expected ROI', AppState.data.results.roi.toFixed(1) + '%'],
         ['Break-even Period', AppState.data.results.breakEvenMonths + ' months'],
+        ['Monthly Break-even Sales', formatCurrency(AppState.data.results.breakEvenSales)],
+        ['Break-even Tickets', AppState.data.results.breakEvenTickets.toLocaleString()],
+        ['Average Cost per Ticket', formatCurrency(AppState.data.results.avgCostPerTicket)],
         ['Report Generated', new Date().toLocaleDateString()]
     ];
     
@@ -114,8 +117,12 @@ function exportToPDF() {
         ['Average Ticket - Delivery', formatCurrency(premises.averageTicket.delivery)],
         ['Sales Mix - In Store', (premises.ticketRatio.inStore * 100) + '%'],
         ['Sales Mix - Delivery', (premises.ticketRatio.delivery * 100) + '%'],
+        ['Cost of Goods', (premises.cogsPercent * 100) + '%'],
+        ['Delivery Commission', (premises.deliveryCommission * 100) + '%'],
         ['Monthly Ticket Projection', premises.monthlyTickets.toLocaleString()],
-        ['Daily Ticket Average', premises.dailyTickets.toLocaleString()]
+        ['Daily Ticket Average', premises.dailyTickets.toLocaleString()],
+        ['Average Cost per Ticket', formatCurrency(AppState.data.results.avgCostPerTicket)],
+        ['Break-even Tickets', AppState.data.results.breakEvenTickets.toLocaleString()]
     ];
     
     operationalData.forEach(([label, value]) => {

--- a/restaurant-business-calculator/js/ui-controller.js
+++ b/restaurant-business-calculator/js/ui-controller.js
@@ -59,6 +59,21 @@ const UIController = {
             if (value > 100) this.value = 100;
             if (value < 0) this.value = 0;
         });
+
+        // Percentage validation for costs
+        const cogsPercent = document.getElementById('cogs-percent');
+        cogsPercent.addEventListener('input', function() {
+            const value = parseFloat(this.value);
+            if (value > 100) this.value = 100;
+            if (value < 0) this.value = 0;
+        });
+
+        const deliveryCommission = document.getElementById('delivery-commission');
+        deliveryCommission.addEventListener('input', function() {
+            const value = parseFloat(this.value);
+            if (value > 100) this.value = 100;
+            if (value < 0) this.value = 0;
+        });
         
         // Positive number validation
         document.querySelectorAll('input[type="number"]').forEach(input => {


### PR DESCRIPTION
## Summary
- allow configuring cost of goods and delivery commission in pricing strategy
- compute break-even ticket counts and average cost per ticket in results and exports
- update charts and calculations to use net revenue and variable cost ratios

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d50665a48327bfa272df2b7ed62d